### PR TITLE
Add Codex setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Rye if it's not already available
+if ! command -v rye >/dev/null 2>&1; then
+  curl -sSf https://rye-up.com/get | bash
+  source "$HOME/.rye/env"
+fi
+
+# Install project dependencies
+rye sync
+
+# Install test dependencies
+rye run pip install pytest pytest-asyncio


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` for installing dependencies via Rye

## Testing
- `pip install -e .`
- `pip install pytest`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419514c6cc833186b6ee93ac293d64