### PR TITLE
Update Rye installer URL in setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Install Rye if it's not already available
 if ! command -v rye >/dev/null 2>&1; then
-  curl -sSf https://rye-up.com/get | bash
+  curl -sSf https://rye.astral.sh/get | bash
   source "$HOME/.rye/env"
 fi
 


### PR DESCRIPTION
## Summary
- update Rye installation URL in `.codex/setup.sh`

## Testing
- `env PYENV_VERSION=3.11.12 pip install -e .`
- `env PYENV_VERSION=3.11.12 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a065b1b0833196febff346fd6ff2